### PR TITLE
Fixes messed up header view after notifyDataSetChanged() from listadapter

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelper.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelper.java
@@ -60,6 +60,8 @@ public class FadingActionBarHelper {
     private boolean mFirstGlobalLayoutPerformed;
     private View mMarginView;
     private View mListViewBackgroundView;
+    private int mHeaderContainerTop = 0;
+    private int mListViewBackgroundTop = 0;
 
 
     public FadingActionBarHelper actionBarBackground(int drawableResId) {
@@ -287,10 +289,19 @@ public class FadingActionBarHelper {
         float damping = mUseParallax ? 0.5f : 1.0f;
         int dampedScroll = (int) (scrollPosition * damping);
         int offset = mLastDampedScroll - dampedScroll;
-        mHeaderContainer.offsetTopAndBottom(offset);
+        //if offset didn't change and header container view top is 0  but last top position != 0
+        // then we should reset offset to last top position otherwise just use offset
+        int headerTop = mHeaderContainer.getTop();
+        mHeaderContainer.offsetTopAndBottom(offset == 0 && mHeaderContainerTop != 0  && headerTop == 0 ? mHeaderContainerTop : offset);
+        mHeaderContainerTop = mHeaderContainer.getTop();
 
         if (mListViewBackgroundView != null) {
             offset = mLastScrollPosition - scrollPosition;
+            //if offset didn't change and header container view top is 0  but last top position != 0
+            // then we should reset offset to last top position otherwise just use offset
+            int listViewBkgTop = mListViewBackgroundView.getTop();
+            mListViewBackgroundView.offsetTopAndBottom(offset == 0 && mListViewBackgroundTop != 0  && listViewBkgTop == 0 ? mListViewBackgroundTop : offset);
+            mListViewBackgroundTop = mListViewBackgroundView.getTop();
             mListViewBackgroundView.offsetTopAndBottom(offset);
         }
 

--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelper.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelper.java
@@ -302,7 +302,6 @@ public class FadingActionBarHelper {
             int listViewBkgTop = mListViewBackgroundView.getTop();
             mListViewBackgroundView.offsetTopAndBottom(offset == 0 && mListViewBackgroundTop != 0  && listViewBkgTop == 0 ? mListViewBackgroundTop : offset);
             mListViewBackgroundTop = mListViewBackgroundView.getTop();
-            mListViewBackgroundView.offsetTopAndBottom(offset);
         }
 
         if (mFirstGlobalLayoutPerformed) {


### PR DESCRIPTION
After notifyDataSetChanged() from LIstAdapter container view is triggered to relayout all children including header view. During relayout it does not keep offset but sets top position based on gravity to 0. After relayout Helper class is notified about new scroll and listview top visible position is not changed so we can just check for that. If header view top position is 0 but previous top position was <0 and listview first visible position haven't changed we can set header offset to last top position. 
