### PR TITLE
Enable overriding ActionBar alpha value

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
@@ -58,6 +58,7 @@ public abstract class FadingActionBarHelperBase {
     private boolean mFirstGlobalLayoutPerformed;
     private FrameLayout mMarginView;
     private View mListViewBackgroundView;
+    private int mActionBarAlpha = 255;
 
     public final <T extends FadingActionBarHelperBase> T actionBarBackground(int drawableResId) {
         mActionBarBackgroundResId = drawableResId;
@@ -173,7 +174,16 @@ public abstract class FadingActionBarHelperBase {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
             mActionBarBackgroundDrawable.setCallback(mDrawableCallback);
         }
-        mActionBarBackgroundDrawable.setAlpha(0);
+        setActionBarAlpha(0);
+    }
+
+    public int getActionbarAlpha(){
+        return mActionBarAlpha;
+    }
+
+    public void setActionBarAlpha(int alpha){
+        mActionBarBackgroundDrawable.setAlpha(alpha);
+        mActionBarAlpha = alpha;
     }
 
     protected abstract int getActionBarHeight();
@@ -310,7 +320,7 @@ public abstract class FadingActionBarHelperBase {
         int headerHeight = currentHeaderHeight - getActionBarHeight();
         float ratio = (float) Math.min(Math.max(scrollPosition, 0), headerHeight) / headerHeight;
         int newAlpha = (int) (ratio * 255);
-        mActionBarBackgroundDrawable.setAlpha(newAlpha);
+        setActionBarAlpha(newAlpha);
 
         addParallaxEffect(scrollPosition);
     }

--- a/samples/stock/res/layout/activity_navigation_drawer.xml
+++ b/samples/stock/res/layout/activity_navigation_drawer.xml
@@ -18,14 +18,21 @@
          The drawer is given a fixed width in dp and extends the full height of
          the container. A solid background is used for contrast
          with the content view. -->
-    <ListView
+    <LinearLayout
         android:id="@+id/left_drawer"
         android:paddingTop="?android:attr/actionBarSize"
         android:layout_width="240dp"
         android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:choiceMode="singleChoice"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="0dp"
-        android:background="#111"/>
+        android:layout_gravity="start">
+
+        <ListView
+            android:id="@+id/left_drawer_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:choiceMode="singleChoice"
+            android:divider="@android:color/transparent"
+            android:dividerHeight="0dp"
+            android:background="#111"/>
+
+    </LinearLayout>
 </android.support.v4.widget.DrawerLayout>

--- a/samples/stock/src/com/manuelpeinado/fadingactionbar/demo/SampleFragment.java
+++ b/samples/stock/src/com/manuelpeinado/fadingactionbar/demo/SampleFragment.java
@@ -26,7 +26,7 @@ import android.widget.ImageView;
 
 import com.manuelpeinado.fadingactionbar.FadingActionBarHelper;
 
-public class SampleFragment extends Fragment {
+public class SampleFragment extends Fragment implements NavigationDrawerActivity.ActionBarHolder {
     private FadingActionBarHelper mFadingHelper;
     private Bundle mArguments;
 
@@ -58,5 +58,21 @@ public class SampleFragment extends Fragment {
             .contentLayout(R.layout.activity_scrollview)
             .lightActionBar(actionBarBg == R.drawable.ab_background_light);
         mFadingHelper.initActionBar(activity);
+    }
+
+    @Override
+    public void overrideAlpha(int alpha) {
+        if (mFadingHelper != null){
+            mFadingHelper.setActionBarAlpha(alpha);
+        }
+    }
+
+    @Override
+    public int getAlpha(){
+        if (mFadingHelper != null){
+            return mFadingHelper.getActionbarAlpha();
+        } else {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
First of: thanks for this awesome library!

This change makes it possible to override the currrent alpha value of the ActionBar. The main purpose is being able to completely fade in the ActionBar whenever the NavigationDrawer slides in and fade it back to it's original state when the drawer slides back out. This is the same behavior as in the Play Music app.
