### PR TITLE
Preserve LayoutParams of header layout to enable setting a specific height

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
@@ -121,9 +121,6 @@ public abstract class FadingActionBarHelperBase {
         if (mContentView == null) {
             mContentView = inflater.inflate(mContentLayoutResId, null);
         }
-        if (mHeaderView == null) {
-            mHeaderView = inflater.inflate(mHeaderLayoutResId, null, false);
-        }
 
         //
         // See if we are in a ListView, WebView or ScrollView scenario
@@ -223,7 +220,7 @@ public abstract class FadingActionBarHelperBase {
 
         mHeaderContainer = (FrameLayout) webViewContainer.findViewById(R.id.fab__header_container);
         initializeGradient(mHeaderContainer);
-        mHeaderContainer.addView(mHeaderView, 0);
+        addHeaderView(mHeaderContainer, mHeaderLayoutResId);
 
         mMarginView = new FrameLayout(webView.getContext());
         mMarginView.setBackgroundColor(Color.TRANSPARENT);
@@ -244,7 +241,8 @@ public abstract class FadingActionBarHelperBase {
         contentContainer.addView(mContentView);
         mHeaderContainer = (FrameLayout) scrollViewContainer.findViewById(R.id.fab__header_container);
         initializeGradient(mHeaderContainer);
-        mHeaderContainer.addView(mHeaderView, 0);
+        addHeaderView(mHeaderContainer, mHeaderLayoutResId);
+
         mMarginView = (FrameLayout) contentContainer.findViewById(R.id.fab__content_top_margin);
 
         return scrollViewContainer;
@@ -262,7 +260,7 @@ public abstract class FadingActionBarHelperBase {
 
         mHeaderContainer = (FrameLayout) contentContainer.findViewById(R.id.fab__header_container);
         initializeGradient(mHeaderContainer);
-        mHeaderContainer.addView(mHeaderView, 0);
+        addHeaderView(mHeaderContainer, mHeaderLayoutResId);
 
         mMarginView = new FrameLayout(listView.getContext());
         mMarginView.setLayoutParams(new AbsListView.LayoutParams(LayoutParams.MATCH_PARENT, 0));
@@ -351,5 +349,12 @@ public abstract class FadingActionBarHelperBase {
             gradient = R.drawable.fab__gradient_light;
         }
         gradientView.setBackgroundResource(gradient);
+    }
+
+    private void addHeaderView(ViewGroup headerContainer, int headerLayoutResId){
+        if (mHeaderView == null) {
+            mHeaderView = mInflater.inflate(headerLayoutResId, headerContainer, false);
+        }
+        headerContainer.addView(mHeaderView, 0);
     }
 }


### PR DESCRIPTION
Currently a `layout_height` for a header image set in the header layout resource is being ignored.

Consider the following example:

``` xml
<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
    android:layout_width="fill_parent"
    android:layout_height="250dp"
    android:scaleType="centerCrop"
    android:src="@drawable/foobar"/>
```

With that I would expect the header image to have an exact height of 250dp but it doesn't. It seems the actual height just depends on the drawable and probably the ScaleType.

With this change the LayoutParams of the header layout are being kept when inflating to avoid this behavior.
