### PR TITLE
Add property which allows header view to handle touch events.

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
@@ -59,6 +59,7 @@ public abstract class FadingActionBarHelperBase {
     private boolean mFirstGlobalLayoutPerformed;
     private FrameLayout mMarginView;
     private View mListViewBackgroundView;
+    private boolean mAllowHeaderTouchEvents = false;
 
     public final <T extends FadingActionBarHelperBase> T actionBarBackground(int drawableResId) {
         mActionBarBackgroundResId = drawableResId;
@@ -107,6 +108,11 @@ public abstract class FadingActionBarHelperBase {
 
     public final <T extends FadingActionBarHelperBase> T  parallax(boolean value) {
         mUseParallax = value;
+        return (T)this;
+    }
+
+    public final <T extends FadingActionBarHelperBase> T allowHeaderTouchEvents(boolean value) {
+        mAllowHeaderTouchEvents = value;
         return (T)this;
     }
 
@@ -232,6 +238,10 @@ public abstract class FadingActionBarHelperBase {
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         webView.addView(mMarginView);
 
+        if (mAllowHeaderTouchEvents) {
+            setMarginViewTouchListener();
+        }
+
         return webViewContainer;
     }
 
@@ -250,6 +260,10 @@ public abstract class FadingActionBarHelperBase {
         initializeGradient(mHeaderContainer);
         mHeaderContainer.addView(mHeaderView, 0);
         mMarginView = (FrameLayout) contentContainer.findViewById(R.id.fab__content_top_margin);
+
+        if (mAllowHeaderTouchEvents) {
+            setMarginViewTouchListener();
+        }
 
         return scrollViewContainer;
     }
@@ -279,6 +293,11 @@ public abstract class FadingActionBarHelperBase {
         mListViewBackgroundView.setLayoutParams(params);
 
         listView.setOnScrollListener(mOnScrollListener);
+
+        if (mAllowHeaderTouchEvents) {
+            setMarginViewTouchListener();
+        }
+
         return contentContainer;
     }
 
@@ -355,5 +374,14 @@ public abstract class FadingActionBarHelperBase {
             gradient = R.drawable.fab__gradient_light;
         }
         gradientView.setBackgroundResource(gradient);
+    }
+
+    private void setMarginViewTouchListener() {
+        mMarginView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                return mHeaderView.dispatchTouchEvent(event);
+            }
+        });
     }
 }


### PR DESCRIPTION
Previously, the header view could not accept user interaction. By setting the `mAllowHeaderTouchEvents` flag, the margin view will pass touches to the header view to be (possibly) handled.

Common use cases are if the header view contains an ImageView which needs an [OnClickListener](http://developer.android.com/reference/android/view/View.OnClickListener.html) or if you have a more complex header view with buttons or other clickable elements.
