### PR TITLE
Temporary Fix for L Developer Preview

### DIFF
--- a/extras-actionbarcompat/build.gradle
+++ b/extras-actionbarcompat/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 dependencies {
     compile project(':library')
-    compile "com.android.support:appcompat-v7:[19.0,)"
+    compile "com.android.support:appcompat-v7:20.+"
 }
 
 android {

--- a/extras-actionbarsherlock/build.gradle
+++ b/extras-actionbarsherlock/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 dependencies {
     compile project(':library')
-    compile "com.android.support:support-v4:[19.0,)"
+    compile "com.android.support:support-v4:20.+"
     compile ("com.actionbarsherlock:actionbarsherlock:[4.4,)@aar") {
         // Need to specifically exclude this as it is specified in ActionBarSherlock pom
         exclude group: 'com.google.android', module: 'support-v4'


### PR DESCRIPTION
It Won't Compile, when your SDK manager already is on L Preview, since the Support Library Locks out Other targets than L.

ActionbarCompat extras and ActionbarSherlock Extras will fail on compile due to that dependencys

This is a Temporary Fix, until we can gain use the [min,) option
