### PR TITLE
Don't mutate drawable instances fix

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
@@ -168,7 +168,7 @@ public abstract class FadingActionBarHelperBase {
 
     public void initActionBar(Activity activity) {
         if (mActionBarBackgroundDrawable == null) {
-            mActionBarBackgroundDrawable = activity.getResources().getDrawable(mActionBarBackgroundResId);
+            mActionBarBackgroundDrawable = activity.getResources().getDrawable(mActionBarBackgroundResId).getConstantState().newDrawable();
         }
         setActionBarBackgroundDrawable(mActionBarBackgroundDrawable);
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {


### PR DESCRIPTION
Fix a bug where the action bar background drawable could be mutated for other activities by making a new instance of the action bar background drawable.
