### PR TITLE
Support header height change

### DIFF
--- a/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
+++ b/library/src/com/manuelpeinado/fadingactionbar/FadingActionBarHelperBase.java
@@ -157,7 +157,7 @@ public abstract class FadingActionBarHelperBase {
             @Override
             public void onGlobalLayout() {
                 int headerHeight = mHeaderContainer.getHeight();
-                if (!mFirstGlobalLayoutPerformed && headerHeight != 0) {
+                if ((!mFirstGlobalLayoutPerformed || (headerHeight != mLastHeaderHeight)) && headerHeight != 0) {
                     updateHeaderHeight(headerHeight);
                     mFirstGlobalLayoutPerformed = true;
                 }


### PR DESCRIPTION
When the header height is changed after the initialization (for example after an image download) the FadingActionBarHelperBase has to be informed.
