### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Including in your project
 The library is pushed to Maven Central as a AAR, so you just need to add the following dependency to your `build.gradle`.
     
     dependencies {
-        compile 'com.github.manuelpeinado.fadingactionbar:fadingactionbar:3.1.2'
+        implementation 'com.github.manuelpeinado.fadingactionbar:fadingactionbar:3.1.2'
     }
     
 If your project doesn't use the stock action bar, but one of the compatibility implementations, you would use the following:
 
     dependencies {
         // Use the following if your project uses ActionBarCompat
-        compile 'com.github.manuelpeinado.fadingactionbar:fadingactionbar-abc:3.1.2'
+        implementation 'com.github.manuelpeinado.fadingactionbar:fadingactionbar-abc:3.1.2'
         // Or the following if your project uses ActionBarSherlock
-        compile 'com.github.manuelpeinado.fadingactionbar:fadingactionbar-abs:3.1.2'
+        implementation 'com.github.manuelpeinado.fadingactionbar:fadingactionbar-abs:3.1.2'
     }
 
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.